### PR TITLE
Multiple origins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ### 0.10.0.0
 
-* [#183](https://github.com/tweag/webauthn/pull/183) Pass a list of allowed origins instead of a single origin.
+* [#184](https://github.com/tweag/webauthn/pull/184) Pass a list of allowed origins instead of a single origin.
   This is a breaking change needed for allowing native apps to use WebAuthn. It is also needed for Relying Parties
   that want to allow multiple subdomains to access WebAuthn credentials.
   Unlike the rest of this library, which strictly follows the L2 version of this spec, this feature is defined

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+### 0.10.0.0
+
+* [#183](https://github.com/tweag/webauthn/pull/183) Pass a list of allowed origins instead of a single origin.
+  This is a breaking change needed for allowing native apps to use WebAuthn. It is also needed for Relying Parties
+  that want to allow multiple subdomains to access WebAuthn credentials.
+  Unlike the rest of this library, which strictly follows the L2 version of this spec, this feature is defined
+  in the [L3 draft](https://www.w3.org/TR/webauthn-3/#sctn-validating-origin). However because WebAuthn on
+  Native Apps is widely deployed through the push of Passkeys we decided to include this feature in this library early.
+
+
 ### 0.9.0.0
 
 * [#182](https://github.com/tweag/webauthn/pull/182) Migrate to the crypton library ecosystem.

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -47,7 +47,7 @@ import System.Hourglass (dateCurrent)
 import qualified Web.Cookie as Cookie
 import Web.Scotty (ScottyM)
 import qualified Web.Scotty as Scotty
-import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.List.NonEmpty as NE
 
 data RegisterBeginReq = RegisterBeginReq
   { accountName :: Text,
@@ -262,7 +262,7 @@ completeRegistration origin rpIdHash db pending registryVar = do
   -- FIXME
   registry <- Scotty.liftAndCatchIO $ readTVarIO registryVar
   now <- Scotty.liftAndCatchIO dateCurrent
-  result <- case WA.verifyRegistrationResponse (NonEmpty.singleton origin) rpIdHash registry now options cred of
+  result <- case WA.verifyRegistrationResponse (NE.singleton origin) rpIdHash registry now options cred of
     Failure errs@(err :| _) -> do
       Scotty.liftAndCatchIO $ TIO.putStrLn $ "Register complete had errors: " <> Text.pack (show errs)
       fail $ show err

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -18,7 +18,7 @@ import qualified Data.Aeson.Encode.Pretty as AP
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
-import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty (NonEmpty ((:|)), singleton)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
@@ -47,6 +47,7 @@ import System.Hourglass (dateCurrent)
 import qualified Web.Cookie as Cookie
 import Web.Scotty (ScottyM)
 import qualified Web.Scotty as Scotty
+import qualified Data.List.NonEmpty as NonEmpty
 
 data RegisterBeginReq = RegisterBeginReq
   { accountName :: Text,
@@ -261,7 +262,7 @@ completeRegistration origin rpIdHash db pending registryVar = do
   -- FIXME
   registry <- Scotty.liftAndCatchIO $ readTVarIO registryVar
   now <- Scotty.liftAndCatchIO dateCurrent
-  result <- case WA.verifyRegistrationResponse origin rpIdHash registry now options cred of
+  result <- case WA.verifyRegistrationResponse (NonEmpty.singleton origin) rpIdHash registry now options cred of
     Failure errs@(err :| _) -> do
       Scotty.liftAndCatchIO $ TIO.putStrLn $ "Register complete had errors: " <> Text.pack (show errs)
       fail $ show err
@@ -376,7 +377,7 @@ completeLogin origin rpIdHash db pending = do
   -- not be verified.
   let verificationResult =
         WA.verifyAuthenticationResponse
-          origin
+          (singleton origin)
           rpIdHash
           (Just (WA.ceUserHandle entry))
           entry

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -377,7 +377,7 @@ completeLogin origin rpIdHash db pending = do
   -- not be verified.
   let verificationResult =
         WA.verifyAuthenticationResponse
-          (singleton origin)
+          (NE.singleton origin)
           rpIdHash
           (Just (WA.ceUserHandle entry))
           entry

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -18,7 +18,7 @@ import qualified Data.Aeson.Encode.Pretty as AP
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
-import Data.List.NonEmpty (NonEmpty ((:|)), singleton)
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)

--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -158,10 +158,31 @@ newtype AuthenticationResult = AuthenticationResult
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion)
 -- Verifies a 'M.Credential' response for an [authentication ceremony](https://www.w3.org/TR/webauthn-2/#authentication).
+--
 -- The 'arSignatureCounterResult' field of the result should be inspected to
 -- enforce Relying Party policy regarding potentially cloned authenticators.
+--
+-- Though this library implements the WebAuthn L2 spec, for origin validation we
+-- follow the L3 draft. This is because allowing multiple origins is often
+-- needed in the wild. See [Validating the origin of a credential](https://www.w3.org/TR/webauthn-3/#sctn-validating-origin) 
+-- more details.
+-- In the simplest case, just a single origin is allowed and this is the 'M.RpId' with @https://@ prepended:
+--
+-- > verifyAuthenticationResponse (NonEmpty.singleton (M.Origin "https://example.org")) ...
+--
+-- In the more complex case, multiple origins are allowed:
+--
+-- > verifyAuthenticationResponse (M.Origin <$> "https://example.org" :| ["https://signin.example.org"]) ...
+--
+-- One might also allow native apps to authenticate:
+--
+-- > verifyAuthenticationResponse (M.Origin <$> "https://example.org" :| ["ios:bundle-id:org.example.ourapp"]) ...
+--
+-- See Apple's documentation on [associated domains](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_passkeys/)
+-- and Google's documentation on [Digital Asset Links](https://developers.google.com/identity/passkeys/developer-guides) for more information on how to link app
+-- origins to your Relying Party ID.
 verifyAuthenticationResponse ::
-  -- | The origin of the server
+  -- | The list of allowed origins for the ceremony
   NonEmpty.NonEmpty M.Origin ->
   -- | The hash of the relying party id
   M.RpIdHash ->

--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -164,7 +164,7 @@ newtype AuthenticationResult = AuthenticationResult
 --
 -- Though this library implements the WebAuthn L2 spec, for origin validation we
 -- follow the L3 draft. This is because allowing multiple origins is often
--- needed in the wild. See [Validating the origin of a credential](https://www.w3.org/TR/webauthn-3/#sctn-validating-origin) 
+-- needed in the wild. See [Validating the origin of a credential](https://www.w3.org/tr/webauthn-3/#sctn-validating-origin) 
 -- more details.
 -- In the simplest case, just a single origin is allowed and this is the 'M.RpId' with @https://@ prepended:
 --
@@ -312,9 +312,11 @@ verifyAuthenticationResponse origins rpIdHash midentifiedUser entry options cred
       AuthenticationChallengeMismatch (M.coaChallenge options) (M.ccdChallenge c)
 
   -- 13. Verify that the value of C.origin matches the Relying Party's origin.
+  -- NOTE: We follow the L3 draft of the spec here, which allows for multiple origins.
+  -- https://www.w3.org/TR/webauthn-3/#sctn-validating-origin
   unless (M.ccdOrigin c `elem` NonEmpty.toList origins) $
     failure $
-      AuthenticationOriginMismatch  origins (M.ccdOrigin c)
+      AuthenticationOriginMismatch origins (M.ccdOrigin c)
 
   -- 14. Verify that the value of C.tokenBinding.status matches the state of
   -- Token Binding for the TLS connection over which the attestation was

--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -313,7 +313,7 @@ verifyAuthenticationResponse origins rpIdHash midentifiedUser entry options cred
 
   -- 13. Verify that the value of C.origin matches the Relying Party's origin.
   -- NOTE: We follow the L3 draft of the spec here, which allows for multiple origins.
-  -- https://www.w3.org/TR/webauthn-3/#sctn-validating-origin
+  -- https://www.w3.org/TR/webauthn-3/#rp-op-verifying-assertion-step-origin
   unless (M.ccdOrigin c `elem` NonEmpty.toList origins) $
     failure $
       AuthenticationOriginMismatch origins (M.ccdOrigin c)

--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -36,7 +36,7 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import Data.Validation (Validation)
-import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.List.NonEmpty as NE
 
 -- | Errors that may occur during [assertion](https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion)
 data AuthenticationError
@@ -79,7 +79,7 @@ data AuthenticationError
     AuthenticationOriginMismatch
       { -- | The origin explicitly passed to the `verifyAuthenticationResponse`
         -- response, set by the RP
-        aeExpectedOrigin :: NonEmpty.NonEmpty M.Origin,
+        aeExpectedOrigin :: NonEmpty M.Origin,
         -- | The origin received from the client as part of the client data
         aeReceivedOrigin :: M.Origin
       }
@@ -168,7 +168,7 @@ newtype AuthenticationResult = AuthenticationResult
 -- more details.
 -- In the simplest case, just a single origin is allowed and this is the 'M.RpId' with @https://@ prepended:
 --
--- > verifyAuthenticationResponse (NonEmpty.singleton (M.Origin "https://example.org")) ...
+-- > verifyAuthenticationResponse (NE.singleton (M.Origin "https://example.org")) ...
 --
 -- In the more complex case, multiple origins are allowed:
 --
@@ -183,7 +183,7 @@ newtype AuthenticationResult = AuthenticationResult
 -- origins to your Relying Party ID.
 verifyAuthenticationResponse ::
   -- | The list of allowed origins for the ceremony
-  NonEmpty.NonEmpty M.Origin ->
+  NonEmpty M.Origin ->
   -- | The hash of the relying party id
   M.RpIdHash ->
   -- | The user handle, in case the user is identified already
@@ -314,7 +314,7 @@ verifyAuthenticationResponse origins rpIdHash midentifiedUser entry options cred
   -- 13. Verify that the value of C.origin matches the Relying Party's origin.
   -- NOTE: We follow the L3 draft of the spec here, which allows for multiple origins.
   -- https://www.w3.org/TR/webauthn-3/#rp-op-verifying-assertion-step-origin
-  unless (M.ccdOrigin c `elem` NonEmpty.toList origins) $
+  unless (M.ccdOrigin c `elem` NE.toList origins) $
     failure $
       AuthenticationOriginMismatch origins (M.ccdOrigin c)
 

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -370,9 +370,11 @@ verifyRegistrationResponse
           RegistrationChallengeMismatch corChallenge (M.ccdChallenge c)
 
       -- 9. Verify that the value of C.origin matches the Relying Party's origin.
+      -- NOTE: We follow the L3 draft of the spec here, which allows for multiple origins.
+      -- https://www.w3.org/TR/webauthn-3/#sctn-validating-origin
       unless (M.ccdOrigin c `elem` NonEmpty.toList origins) $
         failure $
-          RegistrationOriginMismatch  origins (M.ccdOrigin c)
+          RegistrationOriginMismatch origins (M.ccdOrigin c)
 
       -- 10. Verify that the value of C.tokenBinding.status matches the state of
       -- Token Binding for the TLS connection over which the assertion was

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -267,8 +267,10 @@ deriving instance ToJSON RegistrationResult
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential)
 -- Verifies a 'M.Credential' response for a [registration ceremony](https://www.w3.org/TR/webauthn-2/#registration-ceremony). 
 --
--- The 'arSignatureCounterResult' field of the result should be inspected to
--- enforce Relying Party policy regarding potentially cloned authenticators.
+-- The resulting 'rrEntry' of this call should be stored in a database by the
+-- Relying Party. The 'rrAttestationStatement' contains the result of the
+-- attempted attestation, allowing the Relying Party to reject certain
+-- authenticators/attempted entry creations based on policy.
 --
 -- Though this library implements the WebAuthn L2 spec, for origin validation we
 -- follow the L3 draft. This is because allowing multiple origins is often

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -56,7 +56,6 @@ import qualified Data.X509 as X509
 import qualified Data.X509.CertificateStore as X509
 import qualified Data.X509.Validation as X509
 import GHC.Generics (Generic)
-import qualified Data.List.NonEmpty as NonEmpty
 
 -- | All the errors that can result from a call to 'verifyRegistrationResponse'
 data RegistrationError
@@ -73,7 +72,7 @@ data RegistrationError
     RegistrationOriginMismatch
       { -- | The origin explicitly passed to the `verifyRegistrationResponse`
         -- response, set by the RP
-        reExpectedOrigin :: NonEmpty.NonEmpty M.Origin,
+        reExpectedOrigin :: NonEmpty M.Origin,
         -- | The origin received from the client as part of the client data
         reReceivedOrigin :: M.Origin
       }
@@ -278,7 +277,7 @@ deriving instance ToJSON RegistrationResult
 -- more details.
 -- In the simplest case, just a single origin is allowed and this is the 'M.RpId' with @https://@ prepended:
 --
--- > verifyRegistrationResponse (NonEmpty.singleton (M.Origin "https://example.org")) ...
+-- > verifyRegistrationResponse (NE.singleton (M.Origin "https://example.org")) ...
 --
 -- In the more complex case, multiple origins are allowed:
 --
@@ -293,7 +292,7 @@ deriving instance ToJSON RegistrationResult
 -- origins to your Relying Party ID.
 verifyRegistrationResponse ::
   -- | The list of allowed origins for the ceremony
-  NonEmpty.NonEmpty M.Origin ->
+  NonEmpty M.Origin ->
   -- | The relying party id
   M.RpIdHash ->
   -- | The metadata registry, used for verifying the validity of the
@@ -374,7 +373,7 @@ verifyRegistrationResponse
       -- 9. Verify that the value of C.origin matches the Relying Party's origin.
       -- NOTE: We follow the L3 draft of the spec here, which allows for multiple origins.
       -- https://www.w3.org/TR/webauthn-3/#rp-op-registering-a-new-credential-step-origin
-      unless (M.ccdOrigin c `elem` NonEmpty.toList origins) $
+      unless (M.ccdOrigin c `elem` NE.toList origins) $
         failure $
           RegistrationOriginMismatch origins (M.ccdOrigin c)
 

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -373,7 +373,7 @@ verifyRegistrationResponse
 
       -- 9. Verify that the value of C.origin matches the Relying Party's origin.
       -- NOTE: We follow the L3 draft of the spec here, which allows for multiple origins.
-      -- https://www.w3.org/TR/webauthn-3/#sctn-validating-origin
+      -- https://www.w3.org/TR/webauthn-3/#rp-op-registering-a-new-credential-step-origin
       unless (M.ccdOrigin c `elem` NonEmpty.toList origins) $
         failure $
           RegistrationOriginMismatch origins (M.ccdOrigin c)

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -133,7 +133,7 @@ spec =
           Left errors -> any (\case O.RegistrationOriginMismatch _ _ -> True; _ -> False) errors
           Right _ -> False
     it "rejects unknown origin during login" $ do
-      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 1  ==> do
+      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 1 && not (origin' `elem` allowedOrigins')  ==> do
         let allowedOrigins = M.Origin <$> NE.fromList allowedOrigins'
         let origin = NE.head allowedOrigins
         let wrongOrigin = M.Origin origin'

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -38,7 +38,6 @@ import Emulation.Client.Arbitrary ()
 import Spec.Util (predeterminedDateTime)
 import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
 import Test.QuickCheck (property)
-import qualified Data.List.NonEmpty as NonEmpty
 
 -- | Custom type to combine the MonadPseudoRandom with the Except monad. We
 -- force the ChaChaDRG to ensure the App type is completely pure, and
@@ -85,7 +84,7 @@ register ao conformance authenticator registry now = do
   let registerResult =
         toEither $
           O.verifyRegistrationResponse
-            (NonEmpty.singleton $ aoOrigin ao)
+            (NE.singleton $ aoOrigin ao)
             (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
             registry
             now

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -122,7 +122,7 @@ spec :: SpecWith ()
 spec =
   describe "None" $ do
     it "rejects unknown origin during registration" $  do
-      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 0 && not (origin' `elem` allowedOrigins') ==> do
+      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 0 && origin' `notElem` allowedOrigins' ==> do
         let origin = M.Origin origin'
         let allowedOrigins = M.Origin <$> NE.fromList allowedOrigins'
         let annotatedOrigin = AnnotatedOrigin { aoRpId = M.RpId "localhost", aoOrigin = origin }
@@ -133,7 +133,7 @@ spec =
           Left errors -> any (\case O.RegistrationOriginMismatch _ _ -> True; _ -> False) errors
           Right _ -> False
     it "rejects unknown origin during login" $ do
-      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 1 && not (origin' `elem` allowedOrigins')  ==> do
+      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 1 && origin' `notElem` allowedOrigins'  ==> do
         let allowedOrigins = M.Origin <$> NE.fromList allowedOrigins'
         let origin = NE.head allowedOrigins
         let wrongOrigin = M.Origin origin'

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -122,7 +122,7 @@ spec :: SpecWith ()
 spec =
   describe "None" $ do
     it "rejects unknown origin during registration" $  do
-      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 0 && origin' `notElem` allowedOrigins' ==> do
+      property $ \seed authenticator allowedOrigins' origin' -> not (null allowedOrigins') && origin' `notElem` allowedOrigins' ==> do
         let origin = M.Origin origin'
         let allowedOrigins = M.Origin <$> NE.fromList allowedOrigins'
         let annotatedOrigin = AnnotatedOrigin { aoRpId = M.RpId "localhost", aoOrigin = origin }
@@ -133,7 +133,7 @@ spec =
           Left errors -> any (\case O.RegistrationOriginMismatch _ _ -> True; _ -> False) errors
           Right _ -> False
     it "rejects unknown origin during login" $ do
-      property $ \seed authenticator allowedOrigins' origin' -> length allowedOrigins' > 1 && origin' `notElem` allowedOrigins'  ==> do
+      property $ \seed authenticator allowedOrigins' origin' -> not (null allowedOrigins') && origin' `notElem` allowedOrigins'  ==> do
         let allowedOrigins = M.Origin <$> NE.fromList allowedOrigins'
         let origin = NE.head allowedOrigins
         let wrongOrigin = M.Origin origin'

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -38,6 +38,7 @@ import Emulation.Client.Arbitrary ()
 import Spec.Util (predeterminedDateTime)
 import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
 import Test.QuickCheck (property)
+import qualified Data.List.NonEmpty as NonEmpty
 
 -- | Custom type to combine the MonadPseudoRandom with the Except monad. We
 -- force the ChaChaDRG to ensure the App type is completely pure, and
@@ -84,7 +85,7 @@ register ao conformance authenticator registry now = do
   let registerResult =
         toEither $
           O.verifyRegistrationResponse
-            (aoOrigin ao)
+            (NonEmpty.singleton $ aoOrigin ao)
             (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
             registry
             now
@@ -109,7 +110,7 @@ login ao conformance authenticator ce@O.CredentialEntry {..} = do
     . second O.arSignatureCounterResult
     . toEither
     $ O.verifyAuthenticationResponse
-      (aoOrigin ao)
+      (pure (aoOrigin ao))
       (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
       (Just ceUserHandle)
       ce

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -109,7 +109,7 @@ login ao conformance authenticator ce@O.CredentialEntry {..} = do
     . second O.arSignatureCounterResult
     . toEither
     $ O.verifyAuthenticationResponse
-      (pure (aoOrigin ao))
+      (NE.singleton (aoOrigin ao))
       (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
       (Just ceUserHandle)
       ce

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,7 +27,6 @@ import qualified Data.Hourglass as HG
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import Data.These (These (That, These, This))
@@ -81,7 +80,7 @@ registerTestFromFile fp origin rpId verifiable service now = do
   let registerResult =
         toEither $
           O.verifyRegistrationResponse
-            (NonEmpty.singleton origin)
+            (NE.singleton origin)
             (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ rpId)
             service
             now
@@ -126,7 +125,7 @@ main = Hspec.hspec $ do
             registerResult =
               toEither $
                 O.verifyRegistrationResponse
-                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
+                  (NE.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   registry
                   predeterminedDateTime
@@ -143,7 +142,7 @@ main = Hspec.hspec $ do
             signInResult =
               toEither $
                 O.verifyAuthenticationResponse
-                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
+                  (NE.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   (Just (M.UserHandle "UserId"))
                   credentialEntry
@@ -164,7 +163,7 @@ main = Hspec.hspec $ do
             registerResult =
               toEither $
                 O.verifyRegistrationResponse
-                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
+                  (NE.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   registry
                   predeterminedDateTime
@@ -181,7 +180,7 @@ main = Hspec.hspec $ do
             signInResult =
               toEither $
                 O.verifyAuthenticationResponse
-                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
+                  (NE.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   (Just (M.UserHandle "UserId"))
                   credentialEntry

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,6 +27,7 @@ import qualified Data.Hourglass as HG
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
 import Data.These (These (That, These, This))
@@ -80,7 +81,7 @@ registerTestFromFile fp origin rpId verifiable service now = do
   let registerResult =
         toEither $
           O.verifyRegistrationResponse
-            origin
+            (NonEmpty.singleton origin)
             (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ rpId)
             service
             now
@@ -125,7 +126,7 @@ main = Hspec.hspec $ do
             registerResult =
               toEither $
                 O.verifyRegistrationResponse
-                  (M.Origin "http://localhost:8080")
+                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   registry
                   predeterminedDateTime
@@ -142,7 +143,7 @@ main = Hspec.hspec $ do
             signInResult =
               toEither $
                 O.verifyAuthenticationResponse
-                  (M.Origin "http://localhost:8080")
+                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   (Just (M.UserHandle "UserId"))
                   credentialEntry
@@ -163,7 +164,7 @@ main = Hspec.hspec $ do
             registerResult =
               toEither $
                 O.verifyRegistrationResponse
-                  (M.Origin "http://localhost:8080")
+                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   registry
                   predeterminedDateTime
@@ -180,7 +181,7 @@ main = Hspec.hspec $ do
             signInResult =
               toEither $
                 O.verifyAuthenticationResponse
-                  (M.Origin "http://localhost:8080")
+                  (NonEmpty.singleton $ M.Origin "http://localhost:8080")
                   (M.RpIdHash . hash $ ("localhost" :: ByteString.ByteString))
                   (Just (M.UserHandle "UserId"))
                   credentialEntry


### PR DESCRIPTION
Android and iOS also support WebAuthn just like browsers.

The apps will use their AppStore/PlayStore AppID as the origin. This
means we need to allow a list of origins instead of a single origin.

Apple uses https://developer.apple.com/documentation/xcode/supporting-associated-domains to link
the app origin to the RpId

Google uses an assetlinks.json file:
https://developers.google.com/identity/fido/android/native-apps#interoperability_with_your_website